### PR TITLE
Prepend RSS Title with Feed name

### DIFF
--- a/wordpress.org/public_html/wp-content/plugins/wporg-untagged-posts/wporg-untagged-posts.php
+++ b/wordpress.org/public_html/wp-content/plugins/wporg-untagged-posts/wporg-untagged-posts.php
@@ -53,3 +53,12 @@ function pre_get_posts( $query ) {
 	] );
 }
 add_filter( 'pre_get_posts', __NAMESPACE__ . '\\pre_get_posts' );
+
+/**
+ * Prepend feed name in feed's title tag
+ */
+function prepend_rss_title( $title, $deprecated ) {
+	$title = ucwords( FEED ) . " &#8211; " . $title;
+	return $title;
+}
+add_filter( 'wp_title_rss', __NAMESPACE__ . '\\prepend_rss_title', 10, 2 );


### PR DESCRIPTION
Closes: https://meta.trac.wordpress.org/ticket/5801

This PR adds a filter to prepend "Untagged — " prior to the existing RSS Feed title.